### PR TITLE
fix: Correct Dutch spelling

### DIFF
--- a/custom_components/fiftyfive/translations/nl.json
+++ b/custom_components/fiftyfive/translations/nl.json
@@ -73,8 +73,8 @@
     },
     "services": {
         "start_charge_session": {
-            "name": "Start een laad sessie",
-            "description": "Start een laad sessie met de gegeven laadkaart",
+            "name": "Start een laadsessie",
+            "description": "Start een laadsessie met de gegeven laadkaart",
             "fields": {
                 "device": {
                     "name": "Laadpaal",
@@ -87,8 +87,8 @@
             }
         },
         "stop_charge_session": {
-            "name": "Stop een laad sessie",
-            "description": "Stopt een laad sessie",
+            "name": "Stop een laadsessie",
+            "description": "Stopt een laadsessie",
             "fields": {
                 "device": {
                     "name": "Laadpaal",


### PR DESCRIPTION
I noticed two mistakes in the Dutch translations:

1. "blokeer", where "blokkeer" would be correct
2. "laad sessie", where "laadsessie" would be correct

This PR fixes both in one go.